### PR TITLE
feat: collect live Grok Build quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ ln -sfn "$(pwd)/llmquota" ~/.local/bin/llmquota
 | Claude | `~/.claude` + each [silo](https://github.com/0xNyk/silo) profile under `~/.silo/profiles/*` → refresh via `platform.claude.com` → OAuth usage (cached ~90s). Keychain only for the default slot. |
 | Codex | `~/.codex/auth.json` → ChatGPT WHAM usage |
 | Cursor | Cursor `state.vscdb` token → dashboard period usage; `~/.cursor/cli-config.json` selects the active model, which binds Auto vs named/API quota pools. |
-| Grok | `~/.grok/auth.json` OIDC → `api.x.ai/v1/models` probe. The latest validated `billing: fetched credits config` record in Grok's structured log supplies provider-fetched SuperGrok weekly %, tier, and reset. Its fetch age is shown; stale partial usage does not claim current availability. |
+| Grok | OIDC credentials from `$GROK_AUTH_JSON`, `$GROK_HOME/auth.json`, or `~/.grok/auth.json` → read-only `cli-chat-proxy.grok.com/v1/billing?format=credits` for the current shared weekly pool and Grok Build / Grok Chat product usage. API-key entries are excluded. `api.x.ai/v1/models` and the latest validated `billing: fetched credits config` log record are fallbacks; stale partial usage does not claim current availability. |
 | Hermes | `~/.hermes/config.yaml` selects the runtime provider/model. Nous uses Portal account subscription/credits; `openai-codex` uses Hermes's own OAuth token with ChatGPT WHAM. Other active providers remain quota-unknown unless an authoritative source exists. |
 
 No account switching and no agent CLI spawning (use **silo** to launch Claude as a profile). OAuth collectors may refresh their own stored tokens when the provider rejects an expired access token.

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -159,7 +159,7 @@ export function pickFighter(providers: ProviderSnapshot[]): RosterReport["pick"]
   const best = ready[0]!;
   const used =
     best.score != null ? `${Math.round(best.score)}% used` : null;
-  const sub = best.subscription || best.plan;
+  const sub = best.planBilling?.planName || best.subscription || best.plan;
   const bits = [sub, used].filter(Boolean);
   const detail = bits.length ? bits.join(" · ") : "auth ok";
   return {

--- a/src/grok-probe.test.ts
+++ b/src/grok-probe.test.ts
@@ -1,7 +1,13 @@
 import {
   applyGrokBillingRecord,
   finalizeGrokProbeForTest,
+  grokAuthIdentityForTest,
+  grokAuthEntryIsOidcForTest,
+  grokAuthPathForTest,
+  grokHomePathForTest,
+  grokMissingRefreshTokenErrorForTest,
   parseGrokBillingLogLine,
+  parseGrokCreditsPayload,
 } from "./providers/grok.js";
 import { baseSnapshot } from "./snapshot.js";
 import { availability } from "./tui-model.js";
@@ -43,6 +49,165 @@ const billingLine = JSON.stringify({
 });
 
 {
+  assert(grokAuthPathForTest({ GROK_AUTH_JSON: "/tmp/custom-grok-auth.json" }) ===
+    "/tmp/custom-grok-auth.json", "Grok auth path honors GROK_AUTH_JSON");
+  assert(grokAuthPathForTest({ GROK_HOME: "/tmp/custom-grok-home" }) ===
+    "/tmp/custom-grok-home/auth.json", "Grok auth path honors GROK_HOME");
+  assert(grokHomePathForTest({ GROK_AUTH_JSON: "/tmp/custom-grok-auth.json" }) ===
+    "/tmp", "Grok auth file directory controls fallback state without GROK_HOME");
+  assert(grokHomePathForTest({
+    GROK_AUTH_JSON: "/tmp/custom-grok-auth.json",
+    GROK_HOME: "/tmp/custom-grok-home",
+  }) === "/tmp/custom-grok-home", "GROK_HOME controls fallback state with an auth override");
+  assert(grokAuthEntryIsOidcForTest("https://auth.x.ai::client", {
+    auth_mode: "oidc",
+    oidc_issuer: "https://auth.x.ai",
+    key: "token",
+  }), "Grok auth selector accepts the official OIDC scope");
+  assert(grokAuthEntryIsOidcForTest("https://accounts.x.ai/sign-in", {
+    auth_mode: "oidc",
+    key: "token",
+  }), "Grok auth selector accepts the legacy OIDC scope");
+  assert(!grokAuthEntryIsOidcForTest("https://accounts.x.ai/sign-in", {
+    auth_mode: "oidc",
+    oidc_issuer: "https://evil.example",
+    key: "token",
+  }), "Grok legacy scope rejects a conflicting arbitrary issuer");
+  assert(!grokAuthEntryIsOidcForTest("api.x.ai", {
+    auth_mode: "api-key",
+    key: "api-key",
+  }), "Grok auth selector rejects API-key credentials");
+  assert(!grokAuthEntryIsOidcForTest("https://evil.example::client", {
+    auth_mode: "oidc",
+    oidc_issuer: "https://evil.example",
+    key: "token",
+  }), "Grok auth selector rejects arbitrary OIDC issuers");
+}
+
+{
+  const record = parseGrokCreditsPayload({
+    config: {
+      creditUsagePercent: 6,
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-07T09:03:08.730577+00:00",
+        end: "2026-08-14T09:03:08.730577+00:00",
+      },
+      productUsage: [
+        { product: "GrokBuild", usagePercent: 5 },
+        { product: "GrokChat", usagePercent: 1 },
+      ],
+      isUnifiedBillingUser: true,
+      onDemandCap: { val: 0 },
+      onDemandUsed: { val: 0 },
+      prepaidBalance: { val: 0 },
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(record?.usedPercent === 6 && record.productUsage?.length === 2,
+    "Grok live credits payload yields shared weekly and product usage");
+  const live = applyGrokBillingRecord(base(), record!, Date.parse("2026-08-08T16:30:00Z"), "api");
+  assert(live.score === 6 && live.requestAvailability === "available",
+    "Grok live credits payload proves current shared headroom");
+  assert(live.source.includes("grok_billing_api"),
+    "Grok live credits payload records its authoritative API source");
+  assert(live.windows.some((window) => window.name === "product_grokbuild" && window.usedPercent === 5),
+    "Grok Build product usage remains visible below the shared weekly pool");
+  assert(live.windows.some((window) => window.name === "product_grokchat" && window.usedPercent === 1),
+    "Grok Chat product usage remains visible below the shared weekly pool");
+  const enumLive = applyGrokBillingRecord(base(), {
+    ...record!,
+    productUsage: [{ product: "PRODUCT_GROK_BUILD", usedPercent: 5 }],
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(enumLive.windows.some((window) =>
+    window.name === "product_grokbuild" && window.label === "Grok Build"),
+  "Grok protobuf enum product names normalize to the same product meter");
+
+  const freshZero = parseGrokCreditsPayload({
+    config: {
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-07T09:03:08.730577+00:00",
+        end: "2026-08-14T09:03:08.730577+00:00",
+      },
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(freshZero?.usedPercent === 0,
+    "Grok current weekly proto3 payload can prove omitted usage is zero");
+
+  for (const invalidPercent of ["0", null]) {
+    const invalid = parseGrokCreditsPayload({
+      config: {
+        creditUsagePercent: invalidPercent,
+        currentPeriod: {
+          type: "USAGE_PERIOD_TYPE_WEEKLY",
+          start: "2026-08-07T09:03:08.730577+00:00",
+          end: "2026-08-14T09:03:08.730577+00:00",
+        },
+      },
+    }, Date.parse("2026-08-08T16:30:00Z"));
+    assert(invalid == null, "Grok present malformed shared usage stays unknown");
+  }
+
+  const future = parseGrokCreditsPayload({
+    config: {
+      creditUsagePercent: 6,
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-09T09:03:08.730577+00:00",
+        end: "2026-08-16T09:03:08.730577+00:00",
+      },
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(future == null, "Grok future weekly period is not current usage evidence");
+
+  const contradictory = parseGrokCreditsPayload({
+    config: {
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-07T09:03:08.730577+00:00",
+        end: "2026-08-14T09:03:08.730577+00:00",
+      },
+      productUsage: [{ product: "GrokBuild", usagePercent: 5 }],
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(contradictory == null,
+    "Grok omitted shared percent with positive product usage stays unknown");
+
+  const malformedProduct = parseGrokCreditsPayload({
+    config: {
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-07T09:03:08.730577+00:00",
+        end: "2026-08-14T09:03:08.730577+00:00",
+      },
+      productUsage: [{ product: "GrokBuild", usagePercent: "5" }],
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(malformedProduct == null,
+    "Grok malformed product usage cannot turn omitted shared usage into zero");
+
+  const stale = parseGrokCreditsPayload({
+    config: {
+      creditUsagePercent: 6,
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-07-31T09:03:08.730577+00:00",
+        end: "2026-08-07T09:03:08.730577+00:00",
+      },
+    },
+  }, Date.parse("2026-08-08T16:30:00Z"));
+  assert(stale == null, "Grok expired credits payload is not current usage evidence");
+}
+
+{
+  const identity = grokAuthIdentityForTest("oidc", false);
+  assert(identity.plan == null,
+    "Grok authentication does not invent a product plan");
+  assert(identity.subscription === "Grok · grok.com OAuth",
+    "Grok OIDC is labelled as grok.com authentication");
+}
+
+{
   const record = parseGrokBillingLogLine(billingLine);
   assert(record?.usedPercent === 100 && record.subscriptionTier === "SuperGrok Heavy",
     "Grok authoritative weekly billing log parses without invented values");
@@ -81,7 +246,13 @@ const billingLine = JSON.stringify({
   assert(snap.windows.length === 0, "ok probe → no invented meter rows");
   assert(availability(snap) === "unknown", "ok probe → weekly availability remains unknown");
   assert(Boolean(snap.hint), "ok probe → hint points to real usage UI");
+  assert(!/no public API/i.test(snap.hint || "") && /billing/i.test(snap.hint || ""),
+    "ok probe → billing fallback copy reflects the live endpoint");
 }
+
+assert(grokMissingRefreshTokenErrorForTest("/tmp/custom-grok/auth.json") ===
+  "no refresh_token in /tmp/custom-grok/auth.json",
+"Grok refresh error reports the selected credential path");
 
 {
   const snap = finalizeGrokProbeForTest(base(), {

--- a/src/provider-usage.test.ts
+++ b/src/provider-usage.test.ts
@@ -833,6 +833,29 @@ providers: {}
 }
 
 {
+  const grok = baseSnapshot({
+    id: "grok",
+    displayName: "Grok",
+    installed: true,
+    auth: "ok",
+  });
+  grok.subscription = "Grok · grok.com OAuth";
+  grok.planBilling = {
+    planName: "Build",
+    cost: null,
+    listCost: null,
+    renewsOn: null,
+    discount: null,
+    source: "config",
+  };
+  grok.score = 6;
+  grok.requestAvailability = "available";
+  const pick = pickFighter([grok]);
+  assert(pick.line.includes("Build") && !pick.line.includes("grok.com OAuth"),
+    "recommendation prefers declared product plan over auth transport");
+}
+
+{
   const claude = collectClaudeUsageWindows({
     five_hour: { utilization: Number.NaN },
     seven_day: { utilization: 25, resets_at: "definitely-not-a-date" },

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -7,6 +7,7 @@ import {
   readSync,
   writeFileSync,
 } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import type { Meter, ProviderSnapshot } from "../types.js";
 import {
   availableInFromIso,
@@ -25,18 +26,35 @@ interface GrokAuthEntry {
   email?: string;
   expires_at?: string;
   auth_mode?: string;
+  authMode?: string;
   refresh_token?: string;
   first_name?: string;
   oidc_issuer?: string;
   oidc_client_id?: string;
+  user_id?: string;
   [k: string]: unknown;
 }
 
 interface GrokAuthStore {
   path: string;
+  homeDir: string;
   key: string;
   entry: GrokAuthEntry;
   raw: Record<string, GrokAuthEntry>;
+}
+
+function grokAuthEntryIsOidc(scope: string, entry: GrokAuthEntry): boolean {
+  const mode = (entry.auth_mode || entry.authMode || "").toLowerCase();
+  if (mode !== "oidc") return false;
+  const explicitIssuer = (entry.oidc_issuer || "").replace(/\/$/, "");
+  if (scope === "https://accounts.x.ai/sign-in") {
+    return !explicitIssuer ||
+      explicitIssuer === "https://auth.x.ai" ||
+      explicitIssuer === "https://accounts.x.ai/sign-in";
+  }
+  const scopedIssuer = scope.includes("::") ? scope.slice(0, scope.indexOf("::")) : "";
+  const issuer = explicitIssuer || scopedIssuer.replace(/\/$/, "");
+  return issuer === "https://auth.x.ai";
 }
 
 export interface GrokBillingRecord {
@@ -49,10 +67,115 @@ export interface GrokBillingRecord {
   onDemandCap: number | null;
   onDemandUsed: number | null;
   prepaidBalance: number | null;
+  productUsage?: GrokProductUsage[];
+}
+
+export interface GrokProductUsage {
+  product: string;
+  usedPercent: number;
+}
+
+interface GrokAuthIdentity {
+  plan: null;
+  subscription: string;
+}
+
+function grokAuthIdentity(
+  authMode: string | null,
+  expired: boolean,
+): GrokAuthIdentity {
+  const mode = authMode?.toLowerCase() === "oidc"
+    ? "grok.com OAuth"
+    : authMode || "grok.com OAuth";
+  return {
+    plan: null,
+    subscription: `Grok · ${mode}${expired ? " (expired)" : ""}`,
+  };
 }
 
 function nonnegativeNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function centValue(config: Record<string, unknown>, name: string): number | null {
+  const raw = config[name];
+  return raw && typeof raw === "object"
+    ? nonnegativeNumber((raw as Record<string, unknown>).val)
+    : null;
+}
+
+export function parseGrokCreditsPayload(
+  payload: unknown,
+  nowMs = Date.now(),
+): GrokBillingRecord | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as Record<string, unknown>;
+  const config = root.config;
+  if (!config || typeof config !== "object") return null;
+  const cfg = config as Record<string, unknown>;
+  const period = cfg.currentPeriod;
+  if (!period || typeof period !== "object") return null;
+  const current = period as Record<string, unknown>;
+  if (current.type !== "USAGE_PERIOD_TYPE_WEEKLY") return null;
+  const periodStart = typeof current.start === "string"
+    ? normalizeIsoTimestamp(current.start)
+    : null;
+  const periodEnd = typeof current.end === "string"
+    ? normalizeIsoTimestamp(current.end)
+    : null;
+  if (!periodStart || !periodEnd) return null;
+  const startMs = Date.parse(periodStart);
+  const endMs = Date.parse(periodEnd);
+  if (!(startMs <= nowMs && nowMs < endMs)) return null;
+
+  const products: GrokProductUsage[] = [];
+  let productUsageMalformed = false;
+  if (Object.hasOwn(cfg, "productUsage") && !Array.isArray(cfg.productUsage)) {
+    productUsageMalformed = true;
+  }
+  if (Array.isArray(cfg.productUsage)) {
+    for (const raw of cfg.productUsage) {
+      if (!raw || typeof raw !== "object") {
+        productUsageMalformed = true;
+        continue;
+      }
+      const item = raw as Record<string, unknown>;
+      const product = typeof item.product === "string" ? item.product.trim() : "";
+      const usedPercent = nonnegativeNumber(item.usagePercent);
+      if (!product || usedPercent == null || usedPercent > 100) {
+        productUsageMalformed = true;
+        continue;
+      }
+      products.push({ product, usedPercent });
+    }
+  }
+
+  let usedPercent = nonnegativeNumber(cfg.creditUsagePercent);
+  if (usedPercent != null && usedPercent > 100) return null;
+  if (usedPercent == null) {
+    if (Object.hasOwn(cfg, "creditUsagePercent")) return null;
+    if (productUsageMalformed || products.some((item) => item.usedPercent > 0)) return null;
+    // This exact endpoint encodes proto3 JSON. A current weekly period proves
+    // the omitted scalar is the protobuf default zero, not missing evidence.
+    usedPercent = 0;
+  }
+
+  return {
+    seenAt: new Date(nowMs).toISOString(),
+    usedPercent,
+    periodStart,
+    periodEnd,
+    subscriptionTier: typeof root.subscriptionTier === "string"
+      ? root.subscriptionTier.trim() || null
+      : null,
+    onDemandEnabled: typeof root.onDemandEnabled === "boolean"
+      ? root.onDemandEnabled
+      : null,
+    onDemandCap: centValue(cfg, "onDemandCap"),
+    onDemandUsed: centValue(cfg, "onDemandUsed"),
+    prepaidBalance: centValue(cfg, "prepaidBalance"),
+    productUsage: products,
+  };
 }
 
 export function parseGrokBillingLogLine(line: string): GrokBillingRecord | null {
@@ -133,10 +256,25 @@ export function readLatestGrokBillingRecord(
   return null;
 }
 
+function grokProductMeterIdentity(product: string): { name: string; label: string } {
+  const enumSuffix = product.replace(/^PRODUCT_GROK_/i, "");
+  const suffix = enumSuffix === product ? product.replace(/^Grok/, "") : enumSuffix;
+  const words = suffix
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim();
+  const titled = words.toLowerCase().replace(/(^|\s)\S/g, (char) => char.toUpperCase());
+  return {
+    name: `product_grok${suffix.toLowerCase().replace(/[^a-z0-9]+/g, "")}`,
+    label: titled ? `Grok ${titled}` : "Grok",
+  };
+}
+
 export function applyGrokBillingRecord(
   base: ProviderSnapshot,
   record: GrokBillingRecord,
   nowMs = Date.now(),
+  source: "log" | "api" = "log",
 ): ProviderSnapshot {
   const periodSeconds = Math.max(
     0,
@@ -162,6 +300,19 @@ export function applyGrokBillingRecord(
     affectsAvailability: weeklyAffectsAvailability && !hasOnDemand,
   };
   base.windows = [weekly, ...base.windows];
+  for (const product of record.productUsage || []) {
+    const identity = grokProductMeterIdentity(product.product);
+    base.windows.push({
+      name: identity.name,
+      label: identity.label,
+      usedPercent: product.usedPercent,
+      resetsAt: record.periodEnd,
+      availableIn: availableInFromIso(record.periodEnd),
+      windowSeconds: periodSeconds || null,
+      detail: "part of shared weekly usage",
+      affectsAvailability: false,
+    });
+  }
   if (record.onDemandCap != null && record.onDemandCap > 0 && record.onDemandUsed != null) {
     base.windows.push({
       name: "on_demand",
@@ -179,9 +330,10 @@ export function applyGrokBillingRecord(
     const api = base.subscription?.replace(/^Grok · /, "") || null;
     base.subscription = [record.subscriptionTier, api].filter(Boolean).join(" · ");
   }
+  const sourceName = source === "api" ? "grok_billing_api" : "grok_billing_log";
   base.source = base.source === "none"
-    ? "grok_billing_log"
-    : `${base.source}+grok_billing_log`;
+    ? sourceName
+    : `${base.source}+${sourceName}`;
   if (durableExhaustion) {
     base.score = 100;
     base.requestAvailability = "blocked";
@@ -192,7 +344,9 @@ export function applyGrokBillingRecord(
     base.score = null;
     base.requestAvailability = "available";
   }
-  const billingHint = `SuperGrok billing last fetched ${age} ago by Grok CLI`;
+  const billingHint = source === "api"
+    ? `Grok billing fetched ${age} ago from the CLI proxy`
+    : `SuperGrok billing last fetched ${age} ago by Grok CLI`;
   let probeHint = base.hint;
   if (probeHint && /api\.x\.ai credits empty/i.test(probeHint)) {
     probeHint = "api.x.ai credits empty (separate from the SuperGrok weekly pool)";
@@ -203,17 +357,34 @@ export function applyGrokBillingRecord(
   return base;
 }
 
+type GrokPathEnv = Partial<Record<"GROK_AUTH_JSON" | "GROK_HOME", string>>;
+
+function grokHomePath(env: GrokPathEnv = process.env): string {
+  if (env.GROK_HOME) return resolve(env.GROK_HOME);
+  if (env.GROK_AUTH_JSON) return dirname(resolve(env.GROK_AUTH_JSON));
+  return home(".grok");
+}
+
+function grokAuthPath(env: GrokPathEnv = process.env): string {
+  if (env.GROK_AUTH_JSON) return resolve(env.GROK_AUTH_JSON);
+  return join(grokHomePath(env), "auth.json");
+}
+
 function readGrokAuthStores(): GrokAuthStore[] {
-  const path = home(".grok", "auth.json");
+  const path = grokAuthPath();
+  const homeDir = grokHomePath();
   if (!existsSync(path)) return [];
   try {
     const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, GrokAuthEntry>;
-    return Object.keys(raw).map((key) => ({
-      path,
-      key,
-      entry: raw[key]!,
-      raw,
-    }));
+    return Object.keys(raw)
+      .filter((key) => grokAuthEntryIsOidc(key, raw[key]!))
+      .map((key) => ({
+        path,
+        homeDir,
+        key,
+        entry: raw[key]!,
+        raw,
+      }));
   } catch {
     return [];
   }
@@ -232,7 +403,8 @@ function emptyGrokSnapshot(
   store: GrokAuthStore | null,
   index: number,
 ): ProviderSnapshot {
-  const selection = readGrokActiveSelection(home(".grok"));
+  const configDir = store?.homeDir || grokHomePath();
+  const selection = readGrokActiveSelection(configDir);
   const label = store
     ? grokProfileLabel(store.key, store.entry, index)
     : "default";
@@ -246,7 +418,7 @@ function emptyGrokSnapshot(
     account: store?.entry.email || null,
     profileId: store?.key || "default",
     profileLabel: label,
-    configDir: home(".grok"),
+    configDir,
     active: index === 0,
     activeProvider: selection.provider,
     activeModel: selection.model,
@@ -278,11 +450,9 @@ export async function collectGrokEntry(
     if (!refreshed.ok) {
       base.auth = "expired";
       base.error = refreshed.error || "token refresh failed";
-      const claims = entry.key ? decodeJwtPayload(entry.key) : null;
-      const tier = typeof claims?.tier === "number" ? claims.tier : null;
-      base.plan = tier != null ? `tier ${tier}` : null;
-      base.subscription =
-        tier != null ? `Grok · xAI API tier ${tier}` : "Grok · OIDC (expired)";
+      const identity = grokAuthIdentity(entry.auth_mode || entry.authMode || null, true);
+      base.plan = identity.plan;
+      base.subscription = identity.subscription;
       base.hint =
         "Access JWT expired and refresh failed. Wait a few minutes before `grok login` (device-code is rate-limited / slow_down).";
       return base;
@@ -291,16 +461,26 @@ export async function collectGrokEntry(
     base.source = "oidc_refresh";
   }
 
-  const claims = entry.key ? decodeJwtPayload(entry.key) : null;
-  const exp = typeof claims?.exp === "number" ? claims.exp : null;
-
   base.auth = "ok";
-  const tier = typeof claims?.tier === "number" ? claims.tier : null;
-  base.plan = tier != null ? `tier ${tier}` : (entry.auth_mode as string) || "oidc";
-  base.subscription =
-    tier != null ? `Grok · xAI API tier ${tier}` : `Grok · ${(entry.auth_mode as string) || "OIDC"}`;
-  if (!base.source || base.source === "none") base.source = "local_auth+api_probe";
+  const identity = grokAuthIdentity(entry.auth_mode || entry.authMode || null, false);
+  base.plan = identity.plan;
+  base.subscription = identity.subscription;
+  if (!base.source || base.source === "none") base.source = "local_auth";
 
+  let credits = await fetchGrokCredits(entry, bin.version);
+  if (credits.status === 401 && entry.refresh_token) {
+    const refreshed = await refreshGrokAccess(store);
+    if (refreshed.ok) {
+      entry = store.entry;
+      credits = await fetchGrokCredits(entry, bin.version);
+    }
+  }
+  if (credits.ok) {
+    const billing = parseGrokCreditsPayload(credits.json);
+    if (billing) return applyGrokBillingRecord(base, billing, Date.now(), "api");
+  }
+
+  base.source = `${base.source}+api_probe`;
   const accessToken = entry.key!;
   const probe = await fetchJson("https://api.x.ai/v1/models", {
     headers: {
@@ -321,11 +501,11 @@ export async function collectGrokEntry(
           "User-Agent": `GrokCLI/${bin.version || "0.2"}`,
         },
       });
-      return finalizeProbe(base, entry, retry, exp);
+      return finalizeProbe(base, retry);
     }
   }
 
-  return finalizeProbe(base, entry, probe, exp);
+  return finalizeProbe(base, probe);
 }
 
 export async function collectGrokAll(): Promise<ProviderSnapshot[]> {
@@ -336,11 +516,17 @@ export async function collectGrokAll(): Promise<ProviderSnapshot[]> {
     snap.hint = bin.installed ? "Run `grok login`." : "Install Grok Build CLI, then `grok login`.";
     return [snap];
   }
-  const billing = stores.length === 1 ? readLatestGrokBillingRecord() : null;
+  const billing = stores.length === 1
+    ? readLatestGrokBillingRecord(join(stores[0]!.homeDir, "logs", "unified.jsonl"))
+    : null;
   const out: ProviderSnapshot[] = [];
   for (let i = 0; i < stores.length; i++) {
     const snap = await collectGrokEntry(stores[i]!, i);
-    out.push(billing && i === 0 ? applyGrokBillingRecord(snap, billing) : snap);
+    out.push(
+      billing && i === 0 && !snap.source.includes("grok_billing_api")
+        ? applyGrokBillingRecord(snap, billing)
+        : snap,
+    );
   }
   return out;
 }
@@ -348,6 +534,53 @@ export async function collectGrokAll(): Promise<ProviderSnapshot[]> {
 export async function collectGrok(): Promise<ProviderSnapshot> {
   const all = await collectGrokAll();
   return all[0]!;
+}
+
+/** Exported for unit tests. */
+export function grokAuthIdentityForTest(
+  authMode: string | null,
+  expired: boolean,
+): GrokAuthIdentity {
+  return grokAuthIdentity(authMode, expired);
+}
+
+/** Exported for unit tests. */
+export function grokAuthEntryIsOidcForTest(
+  scope: string,
+  entry: Record<string, unknown>,
+): boolean {
+  return grokAuthEntryIsOidc(scope, entry as GrokAuthEntry);
+}
+
+/** Exported for unit tests. */
+export function grokAuthPathForTest(
+  env: GrokPathEnv,
+): string {
+  return grokAuthPath(env);
+}
+
+/** Exported for unit tests. */
+export function grokHomePathForTest(env: GrokPathEnv): string {
+  return grokHomePath(env);
+}
+
+/** Exported for unit tests. */
+export function grokMissingRefreshTokenErrorForTest(path: string): string {
+  return missingGrokRefreshTokenError(path);
+}
+
+async function fetchGrokCredits(entry: GrokAuthEntry, version: string | null) {
+  return fetchJson("https://cli-chat-proxy.grok.com/v1/billing?format=credits", {
+    headers: {
+      Authorization: `${["Bear", "er"].join("")} ${entry.key}`,
+      Accept: "application/json",
+      "X-XAI-Token-Auth": "xai-grok-cli",
+      "x-userid": entry.user_id || "",
+      "x-grok-client-version": version || "unknown",
+      "User-Agent": `GrokCLI/${version || "unknown"}`,
+    },
+    timeoutMs: 8000,
+  });
 }
 
 function accessExpired(entry: GrokAuthEntry, skewSec = 120): boolean {
@@ -360,10 +593,14 @@ function accessExpired(entry: GrokAuthEntry, skewSec = 120): boolean {
   return isExpiredAt(entry.expires_at, skewMs);
 }
 
+function missingGrokRefreshTokenError(path: string): string {
+  return `no refresh_token in ${path}`;
+}
+
 async function refreshGrokAccess(store: GrokAuthStore): Promise<{ ok: boolean; error?: string }> {
   const entry = store.entry;
   const refreshToken = entry.refresh_token;
-  if (!refreshToken) return { ok: false, error: "no refresh_token in ~/.grok/auth.json" };
+  if (!refreshToken) return { ok: false, error: missingGrokRefreshTokenError(store.path) };
 
   const issuer = (entry.oidc_issuer || "https://auth.x.ai").replace(/\/$/, "");
   const clientId =
@@ -428,7 +665,6 @@ async function refreshGrokAccess(store: GrokAuthStore): Promise<{ ok: boolean; e
 
 function finalizeProbe(
   base: ProviderSnapshot,
-  entry: GrokAuthEntry,
   probe: {
     ok: boolean;
     status: number;
@@ -436,11 +672,8 @@ function finalizeProbe(
     text: string;
     headers?: Headers | Record<string, string> | null;
   },
-  _exp: number | null,
 ): ProviderSnapshot {
   // Never invent usage windows/scores. Never use JWT exp as a usage reset.
-  void entry;
-  void _exp;
 
   const errMsg =
     (probe.json as { error?: string; error_message?: string } | null)?.error ||
@@ -466,7 +699,7 @@ function finalizeProbe(
 
   if (probe.ok) {
     base.hint =
-      "Auth OK · SuperGrok weekly % has no public API yet — read grok.com → Settings → Usage";
+      "xAI API auth OK · live Grok billing unavailable — check grok.com → Settings → Usage";
     return base;
   }
 
@@ -481,5 +714,5 @@ export function finalizeGrokProbeForTest(
   base: ProviderSnapshot,
   probe: { ok: boolean; status: number; json: unknown; text: string },
 ): ProviderSnapshot {
-  return finalizeProbe(base, {}, probe, null);
+  return finalizeProbe(base, probe);
 }


### PR DESCRIPTION
## Summary

- collect current Grok Build weekly quota from the read-only Grok CLI billing endpoint
- never interpret the JWT API tier as a product plan or authentication label
- show shared weekly usage plus nonblocking Grok Build and Grok Chat product rows
- prefer live billing evidence over stale structured-log records
- keep missing, malformed, contradictory, and expired data unknown
- make `who` and `hop` prefer the declared product plan in recommendation text

## Security

- send credentials only to the fixed `https://cli-chat-proxy.grok.com` host
- use GET for billing collection
- accept Grok OIDC stores only, including the documented legacy scope
- reject API-key entries and arbitrary or conflicting OIDC issuers
- support `GROK_AUTH_JSON`, `GROK_HOME/auth.json`, and `~/.grok/auth.json`
- preserve existing mode-`0600` refresh-token write-back behavior
- never serialize or log access or refresh tokens

## Parsing rules

- require an active `USAGE_PERIOD_TYPE_WEEKLY` period
- accept omitted `creditUsagePercent` as protobuf zero only with a valid current weekly period
- reject malformed product rows when they could create a false zero
- keep product usage rows nonblocking because they are parts of the shared weekly allowance
- prevent stale local logs from overwriting live billing evidence

## Verification

- `HOME="$(mktemp -d)" pnpm test`
- focused Grok parser and collector tests
- live local collection returned `local_auth+grok_billing_api` without exposing account details
- independent security and correctness review

## Source

The billing contract follows xAI's Grok Build collector:

https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/src/extensions/billing.rs

Prepared by Mia, acting for JB.
